### PR TITLE
Support older perls that don't support //

### DIFF
--- a/lib/App/pathed.pm
+++ b/lib/App/pathed.pm
@@ -46,7 +46,7 @@ sub run {
 # separate methods so it's easily testable
 sub process {
     my ($path, $opt) = @_;
-    my $separator = $opt->{sep} // $Config::Config{path_sep};
+    my $separator = defined $opt->{sep} ? $opt->{sep} : $Config::Config{path_sep};
     my @parts = split $separator => $path;
     if ($opt->{append}) {
         push @parts, @{ $opt->{append} };


### PR DESCRIPTION
Sadly my default perl doesn't support defined-or //, so here's my patch. It might be worth incorporating this into a future version, but doesn't merit a  release unto itself.
